### PR TITLE
Fix P0/P1: remove dead init dirs, log feedback failures louder

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -241,7 +241,8 @@ pub fn evaluate_llm(
         let queue = FeedbackQueue::new(&session_dir);
         let fb = Feedback::warning(&feedback);
         if let Err(e) = queue.write(&fb) {
-            eprintln!("Warning: failed to write feedback: {}", e);
+            eprintln!("ERROR: failed to write feedback file: {}", e);
+            eprintln!("FEEDBACK CONTENT (fallback):\n{}", feedback);
         }
         // Record to decision journal for audit trail (session-namespaced per user requirement)
         let journal = Journal::new(&session_dir);

--- a/src/init.rs
+++ b/src/init.rs
@@ -73,9 +73,8 @@ pub fn init_at(base_dir: &Path, force: bool) -> Result<(), InitError> {
         return Err(InitError::AlreadyExists);
     }
 
-    // Create directory structure
-    fs::create_dir_all(superego_dir.join("decisions"))?;
-    fs::create_dir_all(superego_dir.join("session"))?;
+    // Create .superego directory (subdirs created on-demand)
+    fs::create_dir_all(&superego_dir)?;
 
     // Write default prompt
     fs::write(superego_dir.join("prompt.md"), DEFAULT_PROMPT)?;
@@ -261,8 +260,6 @@ mod tests {
         init_at(dir.path(), false).unwrap();
 
         assert!(dir.path().join(".superego").exists());
-        assert!(dir.path().join(".superego/decisions").exists());
-        assert!(dir.path().join(".superego/session").exists());
         assert!(dir.path().join(".superego/prompt.md").exists());
         assert!(dir.path().join(".superego/state.json").exists());
         assert!(dir.path().join(".superego/config.yaml").exists());


### PR DESCRIPTION
## Summary

- Remove unused directory creation at init time (`decisions/`, `session/`)
- Improve feedback write failure handling with louder logging

## Details

**P0: Dead directory creation**
- `init.rs` created `session` (singular) but code uses `sessions` (plural)
- Both `decisions/` and `sessions/` are created on-demand elsewhere
- Simplified to just create `.superego/` base directory

**P1: Silent feedback failures**
- Changed warning to ERROR level when feedback file write fails
- Print feedback content to stderr as fallback (appears in hook.log)

## Test plan

- [x] `cargo test` passes (35/35)
- [x] `cargo clippy` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for feedback write failures with clearer error messages and explicit feedback payload visibility to enhance troubleshooting.

* **Refactor**
  * Optimized application initialization by deferring directory creation to on-demand rather than upfront, reducing startup overhead and improving initialization efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->