### PR TITLE
Fix: Add soft block for superego eval session tools

### DIFF
--- a/opencode-plugin/src/index.ts
+++ b/opencode-plugin/src/index.ts
@@ -240,7 +240,7 @@ export const Superego: Plugin = async ({ directory, client }) => {
               await client.session.prompt({
                 path: { id: sessionId },
                 body: {
-                  parts: [{ type: "text", text: `SUPEREGO FEEDBACK: ${testFeedback}` }],
+                  parts: [{ type: "text", text: `SUPEREGO FEEDBACK:\n\n${testFeedback}` }],
                 },
               });
               log(superegoDir, "Test feedback injected");
@@ -266,7 +266,7 @@ export const Superego: Plugin = async ({ directory, client }) => {
           log(superegoDir, `Eval session created: ${evalSessionId}`);
           evalSessionIds.add(evalSessionId); // Track to prevent recursive evaluation
 
-          const evalPrompt = `${prompt}\n\n---\n\n## Conversation to Evaluate\n\n${conversation}`;
+          const evalPrompt = `${prompt}\n\nIMPORTANT: You are a verifier only. Output DECISION and feedback text. DO NOT USE TOOLS.\n\n---\n\n## Conversation to Evaluate\n\n${conversation}`;
 
           log(superegoDir, `Calling LLM via OpenCode with model ${modelString || "default"}...`);
           // session.prompt() returns the AssistantMessage response directly
@@ -276,6 +276,7 @@ export const Superego: Plugin = async ({ directory, client }) => {
             body: {
               model: originalModel ? { providerID: originalModel.providerID, modelID: originalModel.modelID } : undefined,
               parts: [{ type: "text", text: evalPrompt }],
+              tools: { write: false, edit: false, bash: false },  // Eval session has no tools
             },
           });
 
@@ -310,7 +311,7 @@ export const Superego: Plugin = async ({ directory, client }) => {
               await client.session.prompt({
                 path: { id: sessionId },
                 body: {
-                  parts: [{ type: "text", text: `SUPEREGO FEEDBACK: ${feedback}` }],
+                  parts: [{ type: "text", text: `SUPEREGO FEEDBACK:\n\n${feedback}` }],
                 },
               });
               log(superegoDir, `Feedback injected into session ${sessionId}`);


### PR DESCRIPTION
## Summary

Addresses #5 - Superego's eval LLM using tools instead of just outputting DECISION

## The Problem

When superego evaluates a conversation, its eval session has full tool access. The eval LLM should ONLY output `DECISION: ALLOW/BLOCK` + feedback text, never use tools.

## Solution

**Soft block:** Eval prompt includes directive: "IMPORTANT: You are a verifier only. Output DECISION and feedback text. DO NOT USE TOOLS."

## What Didn't Work

| Approach | Result |
|----------|--------|
| `tool.execute.before` throwing error | Crashes OpenCode (trace trap) |
| `permission.ask` hook | Only fires when tools configured with `"ask"` permission |

## Limitation

This is a **soft block only** - it relies on the eval LLM complying with the instruction. A proper hard block requires OpenCode SDK support for session-level tool disable.

## Test plan

- [ ] Verify eval LLM outputs DECISION text, not tool calls
- [ ] Verify OpenCode doesn't crash on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Feedback injections now include a newline after the label for clearer, newline-separated feedback in UI, PDFs, and logs.

* **Bug Fixes**
  * Evaluation prompts now include an explicit verifier-only instruction and disable tool usage during evaluation sessions.
  * Test-mode behavior preserved except for the feedback formatting change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->