### PR TITLE
Fix: Handle markdown formatting in DECISION parsing

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -65,9 +65,7 @@ pub struct LlmEvaluationResult {
 /// Strip common markdown formatting from a line
 /// Handles: # headings, > blockquotes, * bold/italic
 fn strip_markdown_prefix(line: &str) -> &str {
-    line.trim()
-        .trim_start_matches(['#', '>', '*'])
-        .trim()
+    line.trim().trim_start_matches(['#', '>', '*']).trim()
 }
 
 /// Parse the structured decision response from the LLM


### PR DESCRIPTION
## Summary

Fixes the stop-hook interface bug where `DECISION: ALLOW` responses were being blocked.

## The Problem

LLMs often output decisions with markdown formatting:
```
## DECISION: ALLOW

Excellent work on this implementation.
```

But the parser expected plain text:
```
DECISION: ALLOW

Excellent work on this implementation.
```

### What Happened

1. LLM returns `## DECISION: ALLOW` (markdown heading)
2. Parser uses `strip_prefix("DECISION:")` which fails (line starts with `## `)
3. Falls through to legacy handling (line 118)
4. Legacy check: `response != "No concerns."` → `has_concerns = true`
5. Feedback written to queue despite ALLOW decision
6. Hook sees non-empty feedback file → outputs `{"decision":"block"}`
7. **Result**: ALLOW decisions blocked, creating infinite approval loops

### Evidence from Production Logs

```
[10:37:39] [pre-tool] Blocking with feedback: ## DECISION: ALLOW
[10:37:39] [pre-tool] Outputting: {"decision": "block", ...}
```

The hook blocked despite the LLM saying ALLOW.

## The Fix

Add `strip_markdown_prefix()` helper that strips common markdown formatting before checking for `DECISION:` prefix:

- `#` headings (`##`, `###`, etc.)
- `>` blockquotes
- `*` bold/italic markers

Also strips trailing `*` from decision value to handle `DECISION:** ALLOW` format.

## Testing

Added 4 new tests covering markdown variations:
- `test_parse_decision_markdown_heading`
- `test_parse_decision_markdown_bold`
- `test_parse_decision_markdown_blockquote`
- `test_strip_markdown_prefix`

All 42 tests pass.

## Test plan

- [x] Unit tests pass
- [ ] Manual test: trigger superego evaluation with markdown-formatted response
- [ ] Verify ALLOW decisions no longer block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decision parsing to handle common markdown variations (headings, bold, blockquotes, list markers and other leading prefixes), normalizing lines before detecting decisions for more reliable extraction.

* **Tests**
  * Added tests covering decision responses formatted with headings, bold text, blockquotes and multiple prefix forms to ensure consistent parsing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->