### PR TITLE
Fix phantom edit warnings by cleaning up stale pending_change.txt

### DIFF
--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -45,6 +45,11 @@ curl -sS --max-time 5 "$PROMPT_URL" -o "$PROMPT_PATH.tmp" 2>/dev/null && \
 # .superego/ exists - log session start
 echo "[$(date '+%H:%M:%S')] [session] Session started" >> "$PROJECT_DIR/.superego/hook.log" 2>/dev/null
 
+# Clean up stale pending_change.txt files from previous sessions
+# These can persist if a session crashes mid-evaluation, causing "phantom edit" warnings
+rm -f "$PROJECT_DIR/.superego/pending_change.txt" 2>/dev/null
+find "$PROJECT_DIR/.superego/sessions" -name "pending_change.txt" -delete 2>/dev/null
+
 # SCENARIO 2: .superego/ exists but binary missing - offer to install
 if ! command -v sg &> /dev/null; then
     echo "[$(date '+%H:%M:%S')] [session] sg binary not found - requesting install" >> "$PROJECT_DIR/.superego/hook.log" 2>/dev/null


### PR DESCRIPTION
## Summary

Fixes "phantom edit" warnings where superego reports pending edits that don't exist on disk.

**Root cause:** When a session crashes mid-evaluation, `pending_change.txt` files persist in `.superego/sessions/*/`. On next session start, superego reads these stale files and reports them as "pending edits" - causing confusing warnings about edits that don't exist.

**Fix:** Clean up all `pending_change.txt` files at session start. This is safe because:
- At session start, the current session's directory doesn't exist yet
- Any existing `pending_change.txt` is from a previous (ended/crashed) session  
- The file should only exist briefly during active evaluation anyway

## Changes

- `plugin/scripts/session-start.sh`: Add cleanup of stale `pending_change.txt` files from root `.superego/` and all session directories

## Test plan

- [x] Start a new Claude Code session in a project with `.superego/`
- [x] Verify no phantom edit warnings appear
- [x] Manually create a stale `pending_change.txt` and verify it gets cleaned up on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced session initialization by cleaning up stale session artifacts to ensure more reliable session starts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->