### PR TITLE
Add reduce-WIP check to prevent task proliferation

### DIFF
--- a/default_prompt.md
+++ b/default_prompt.md
@@ -204,6 +204,32 @@ If capabilities are being ignored:
 
 This isn't about forcing tool use—it's about ensuring the agent isn't doing extra work when better options exist in its own toolkit.
 
+### Reduce Work-in-Progress (WIP)
+
+Context switching kills momentum. Watch for task proliferation.
+
+**Signs of excessive WIP:**
+- Starting a new task before completing the current one
+- Multiple unrelated changes in the same session
+- "While I'm here..." leading to tangents
+- User redirects treated as immediate pivots rather than queued work
+
+**Healthy pattern:**
+1. Complete current task (or reach a clean stopping point)
+2. Commit/PR the work
+3. Queue new requests for next focus block
+4. Only then switch to new work
+
+**When user introduces new work mid-task:**
+- Acknowledge and add to queue (todo list or explicit note)
+- Continue current work to completion
+- Only pivot if user explicitly says "drop this, do that instead"
+
+If excessive WIP detected:
+> "You have [N] things in flight. Consider completing [current task] before starting [new thing], or explicitly queue it."
+
+This isn't about refusing work—it's about maintaining focus and finishing what's started.
+
 ---
 
 ## METHOD: Gather Evidence, Then Assess


### PR DESCRIPTION
## Summary

Adds a supporting check to flag when the agent is context-switching too much instead of completing work.

## Changes

New section in SUPPORTING CHECKS: **Reduce Work-in-Progress (WIP)**

- Detects signs of excessive WIP (starting new tasks before completing current ones)
- Recommends healthy pattern: complete → commit → queue → switch
- Provides feedback template when WIP is excessive

## Motivation

Observed in a session where Claude switched between:
1. Guardrails/metis integration work
2. Short-ID feature for endeavors
3. This prompt update itself

All in one session, leaving multiple things partially complete.

## Feedback Format

> "You have [N] things in flight. Consider completing [current task] before starting [new thing], or explicitly queue it."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on managing work-in-progress with monitoring recommendations and best practices for task completion

* **New Features**
  * Introduced user-facing alert system for detecting and notifying when work-in-progress levels become excessive

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->