### PR TITLE
feat: simplify Codex skill to single init command

### DIFF
--- a/codex-skill/SKILL.md
+++ b/codex-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: superego
-description: Metacognitive oversight. Invoke with "$superego" to evaluate, "$superego init" to set up, "$superego update" to update, "$superego remove" to uninstall.
+description: Metacognitive oversight. Invoke with "$superego" to evaluate, "$superego init" to set up, "$superego remove" to uninstall.
 ---
 
 # Superego - Metacognitive Oversight
@@ -28,33 +28,50 @@ sg evaluate-codex
 
 ## $superego init
 
-Set up superego for this project. Run these steps:
+Set up superego for this project. Also updates skill files and binary if already installed.
 
-**Step 1:** Install sg binary if not present:
+**Step 1:** Update skill files:
 ```bash
-command -v sg || cargo install superego
+SKILL_DIR="$HOME/.codex/skills/superego"
+
+echo "Updating superego skill files..."
+mkdir -p "$SKILL_DIR/agents"
+
+# Download latest skill files
+for file in AGENTS.md.snippet agents/code.md agents/writing.md agents/learning.md; do
+  curl -fsSL -o "$SKILL_DIR/$file" \
+    "https://raw.githubusercontent.com/cloud-atlas-ai/superego/main/codex-skill/$file"
+done
 ```
 
-**Step 2:** Initialize .superego/ directory:
+**Step 2:** Install or update sg binary:
+```bash
+if command -v sg >/dev/null; then
+  echo "Updating superego binary..."
+  if command -v brew >/dev/null && brew list superego >/dev/null 2>&1; then
+    brew upgrade superego 2>/dev/null || echo "Already up to date"
+  elif command -v cargo >/dev/null; then
+    cargo install superego --force
+  fi
+  echo "Binary version: $(sg --version)"
+else
+  echo "Installing superego binary..."
+  cargo install superego
+fi
+```
+
+**Step 3:** Initialize .superego/ directory:
 ```bash
 sg init
 ```
 
-**Step 3:** Offer to add comprehensive guidance to AGENTS.md:
+**Step 4:** Offer to add comprehensive guidance to AGENTS.md:
 
 Ask user: "Would you like me to add comprehensive superego guidance to AGENTS.md? This includes multi-prompt support, review commands, and usage examples. [Y/n]"
 
 **If yes:**
 ```bash
-# Verify skill is installed
-if [ ! -f ~/.codex/skills/superego/AGENTS.md.snippet ]; then
-  echo "ERROR: Superego skill files not found."
-  echo "Run '$superego update' to download the latest skill files."
-  exit 1
-fi
-
-# Append comprehensive guidance (skip header lines)
-tail -n +5 ~/.codex/skills/superego/AGENTS.md.snippet >> AGENTS.md
+tail -n +5 "$HOME/.codex/skills/superego/AGENTS.md.snippet" >> AGENTS.md
 echo "✓ Added comprehensive superego guidance to AGENTS.md"
 ```
 
@@ -79,7 +96,7 @@ Superego catches strategic mistakes. Use it at **decision points**.
 EOF
 ```
 
-**Step 4:** Confirm to user: "Superego initialized. I'll use $superego at decision points."
+**Step 5:** Confirm to user: "Superego initialized. I'll use $superego at decision points."
 
 ## $superego prompt list
 
@@ -164,51 +181,9 @@ sg review src/main.rs
 
 ## $superego update
 
-Download and install the latest superego skill and binary.
+Alias for `$superego init`. Run that command to update skill files and binary.
 
-**Run:**
-```bash
-SKILL_DIR="$HOME/.codex/skills/superego"
-
-# Get current binary version
-CURRENT=$(sg --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "not installed")
-echo "Current version: $CURRENT"
-
-# Backup and download latest skill files
-if [ -f "$SKILL_DIR/SKILL.md" ]; then
-  cp "$SKILL_DIR/SKILL.md" "$SKILL_DIR/SKILL.md.bak"
-fi
-
-echo "Downloading latest skill files..."
-for file in SKILL.md agents/code.md agents/writing.md agents/learning.md; do
-  mkdir -p "$(dirname "$SKILL_DIR/$file")"
-  curl -fsSL -o "$SKILL_DIR/$file" \
-    "https://raw.githubusercontent.com/cloud-atlas-ai/superego/main/codex-skill/$file"
-done
-
-# Update binary (package managers handle version checking)
-if command -v sg >/dev/null; then
-  echo "Updating binary..."
-  if command -v brew >/dev/null && brew list superego >/dev/null 2>&1; then
-    brew upgrade superego 2>/dev/null || echo "Already up to date"
-  elif command -v cargo >/dev/null; then
-    cargo install superego --force
-  fi
-
-  NEW=$(sg --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-  if [ "$CURRENT" != "$NEW" ]; then
-    echo "✓ Updated binary: v$CURRENT → v$NEW"
-  else
-    echo "✓ Binary already up to date: v$CURRENT"
-  fi
-fi
-
-echo "✓ Update complete. Restart Codex to reload skill files."
-```
-
-**Tell user:** Show the version update summary or "already up to date" message, then "Restart Codex to reload the skill."
-
-**If errors occur:** Tell user to check their internet connection or try again later.
+The init command handles both initial setup and updates.
 
 ## $superego remove
 


### PR DESCRIPTION
## Summary

Simplifies the Codex skill by making `init` handle both initial setup and updates. The `update` command becomes an alias.

## Changes

**`$superego init` now:**
- Always downloads/updates skill files (AGENTS.md.snippet, agents/*.md)
- Always installs/updates sg binary (via brew or cargo)
- Creates `.superego/` directory if needed
- Offers to add AGENTS.md guidance

**`$superego update`:**
- Now just an alias pointing to init
- Helpful for users who expect an "update" command

## Design Rationale

**Simpler is better:**
- One command to remember (init does everything)
- No freshness checking complexity
- No conditional "if missing vs if stale" logic
- Idempotent (safe to run multiple times)

**User flow:**
```bash
# First time
$superego init → downloads files, sets up project

# Later, to update
$superego init → refreshes files, updates binary, project already set up
```

## Benefits

- README instructions stay simple (just download SKILL.md, init handles rest)
- No version sync burden (no version field in SKILL.md)
- No GitHub API dependency (raw file downloads)
- Always ensures latest files when setting up a project

## Testing

Needs testing in actual Codex session to verify bash commands execute correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill description to remove "$superego update" as a separate command reference.
  * Clarified that "$superego init" now handles both initial setup and updates as a combined operation.
  * Reorganized initialization workflow documentation with improved guidance on the unified setup and update process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->