### PR TITLE
Add push/pull evaluation modes, remove interval check

### DIFF
--- a/plugin/scripts/evaluate.sh
+++ b/plugin/scripts/evaluate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Superego evaluation hook
-# Used by: Stop (after response), PreCompact (before context truncation)
+# Used by: Stop (after response), ExitPlanMode permission request
 #
 # AIDEV-NOTE: For Stop hooks, if concerns found and not already blocked once,
 # returns {"decision":"block","reason":"..."} so Claude sees feedback and continues.
@@ -31,6 +31,13 @@ fi
 # Check if superego is initialized
 if [ ! -d "$PROJECT_DIR/.superego" ]; then
     exit 0  # No log - .superego doesn't exist
+fi
+
+# Skip if in pull mode (user calls sg review manually)
+MODE=$(sg mode 2>/dev/null || echo "always")
+if [ "$MODE" = "pull" ]; then
+    log "SKIP: pull mode (use sg review manually)"
+    exit 0
 fi
 
 log "Hook fired"

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -64,8 +64,23 @@ EOFINNER
     exit 0
 fi
 
-# SCENARIO 1: Everything present - inject full superego contract
-cat << 'EOFINNER'
+# SCENARIO 1: Everything present - check mode and inject appropriate context
+MODE=$(sg mode 2>/dev/null || echo "always")
+echo "[$(date '+%H:%M:%S')] [session] Mode: $MODE" >> "$PROJECT_DIR/.superego/hook.log" 2>/dev/null
+
+if [ "$MODE" = "pull" ]; then
+    # Pull mode: Claude decides when to evaluate using `sg review`
+    cat << 'EOFINNER'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "SUPEREGO AVAILABLE (pull mode): This project has superego for metacognitive oversight. Use `sg review` at decision points:\n- Before committing to a plan or approach\n- When choosing between alternatives\n- Before non-trivial implementations\n- When the task feels complex or uncertain\n- Before claiming work is done\n\nSuperego catches strategic mistakes (wrong approach, over-engineering, scope creep). Call it when you need a second opinion, not automatically."
+  }
+}
+EOFINNER
+else
+    # Always mode: automatic evaluation at checkpoints
+    cat << 'EOFINNER'
 {
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
@@ -73,3 +88,4 @@ cat << 'EOFINNER'
   }
 }
 EOFINNER
+fi

--- a/src/init.rs
+++ b/src/init.rs
@@ -72,8 +72,10 @@ pub fn init_at(base_dir: &Path, force: bool) -> Result<(), InitError> {
         superego_dir.join("config.yaml"),
         r#"# Superego configuration
 
-# Periodic evaluation interval (minutes)
-eval_interval_minutes: 5
+# Evaluation mode:
+#   always - Automatic evaluation at checkpoints (Stop, large changes, ExitPlanMode)
+#   pull   - Claude decides when to call `sg review` (Codex-style)
+mode: always
 
 # Carryover context settings (for continuity between evaluations)
 # carryover_decision_count: 2    # Number of recent decisions to include

--- a/src/oh.rs
+++ b/src/oh.rs
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_parse_config_extracts_endeavor_id() {
-        let content = "# Config\neval_interval_minutes: 5\noh_endeavor_id: my-endeavor-123\n";
+        let content = "# Config\nmode: always\noh_endeavor_id: my-endeavor-123\n";
         let result = parse_config_for_endeavor_id(content);
         assert_eq!(result, Some("my-endeavor-123".to_string()));
     }
@@ -661,7 +661,7 @@ mod tests {
 
     #[test]
     fn test_parse_config_returns_none_when_missing() {
-        let content = "eval_interval_minutes: 5\nmodel: opus";
+        let content = "mode: always\nmodel: opus";
         let result = parse_config_for_endeavor_id(content);
         assert!(result.is_none());
     }

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -272,11 +272,7 @@ mod tests {
         let superego = dir.path().join(".superego");
         fs::create_dir_all(&superego).unwrap();
         fs::write(superego.join("prompt.md"), PromptType::Code.content()).unwrap();
-        fs::write(
-            superego.join("config.yaml"),
-            "# Config\neval_interval_minutes: 5\n",
-        )
-        .unwrap();
+        fs::write(superego.join("config.yaml"), "# Config\nmode: always\n").unwrap();
         dir
     }
 


### PR DESCRIPTION
## Problem

Superego was too much of a "backseat driver" - constantly checking in rather than being available when needed.

> "Sg review is amazing. I sometimes turn off automated Sg and just rely on that."
> "Sg can be a back seat driver in normal mode"
> "I think we can get better ux if we get it to back off more"

The manual `sg review` command works well because **the user controls the timing**. The automated hooks didn't respect that.

## Solution Space Rationale

### Why the 5-min interval check was the main problem

The interval check (`eval_interval_minutes: 5`) fired on **every tool call**, using PreToolUse as a "tick" for periodic evaluation. This was purely mechanical - it didn't care whether anything meaningful was happening:

- Reading code for 5 minutes? Trigger eval.
- Deep in a refactor? Trigger eval.
- Just checking git status? Trigger eval.

Clock time is not a semantic signal. The check added noise without value.

### Push vs Pull: Who has agency?

| Model | Who decides when to evaluate? | Trust level |
|-------|------------------------------|-------------|
| Codex (pull) | The LLM | High - "you know when you're at a decision point" |
| Claude Code (push) | The hooks | Low - "we'll check you constantly" |

The Codex skill already implements pull-based evaluation:

```
**When to use $superego:**
- Before committing to a plan or approach
- When choosing between alternatives
- Before non-trivial implementations
- When the task feels complex or uncertain
- Before claiming work is done
```

These are **semantic triggers** - the LLM recognizes decision points based on the nature of the work, not arbitrary intervals.

### The solution: Two modes

**`always` mode (default, cleaned up):**
- SessionStart: inject contract
- Stop: evaluate at response end (natural checkpoint)
- PreToolUse (large changes): evaluate before significant edits
- ExitPlanMode: evaluate before committing to a plan
- **No interval check** - removed entirely

**`pull` mode (new, Codex-style):**
- SessionStart: inject guidance on WHEN to self-evaluate
- No automatic triggers
- Claude calls `sg review` at decision points

Pull mode trusts Claude to recognize decision points, matching the Codex model that already works well.

## Changes

- `config.rs`: Add `Mode` enum (Always/Pull), remove `eval_interval_minutes`
- `main.rs`: Add `sg mode` command, remove `sg should-eval` command
- `init.rs`: Update default config template with mode option
- `session-start.sh`: Inject mode-appropriate context (contract vs guidance)
- `evaluate.sh`, `pre-tool-use.sh`: Skip automatic eval in pull mode

## Test plan

- [x] All 89 tests pass
- [ ] Manual test: `always` mode - Stop/large change/ExitPlanMode triggers work
- [ ] Manual test: `pull` mode - automatic hooks are skipped
- [ ] Manual test: `sg mode` outputs correct mode
- [ ] Manual test: `sg review` still works in both modes

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)