### PR TITLE
OpenCode plugin: add pull mode support and review tool

### DIFF
--- a/opencode-plugin/README.md
+++ b/opencode-plugin/README.md
@@ -100,9 +100,22 @@ mv superego.js ~/.config/opencode/plugin/
 # 3. In each project, ask OpenCode to initialize superego. For example: "use the superego tool to initialize the project"
 ```
 
+## Evaluation Modes
+
+Superego supports two evaluation modes (default: **pull**):
+
+| Mode | Description |
+|------|-------------|
+| `pull` | On-demand evaluation only. Use `superego_review` tool at decision points. (Default) |
+| `always` | Automatic evaluation on session idle (more aggressive). |
+
+To change modes: use the `superego` tool with `mode` command and specify `always` or `pull`.
+
 ## Tool Commands
 
-The plugin provides a single `superego` tool with these commands:
+The plugin provides two tools:
+
+### `superego` - Management commands
 
 | Command | Description |
 |---------|-------------|
@@ -111,10 +124,20 @@ The plugin provides a single `superego` tool with these commands:
 | `disable` | Temporarily disable superego (hooks won't fire) |
 | `enable` | Re-enable superego after disable |
 | `remove` | Remove superego from project (deletes `.superego/`) |
+| `mode` | Show or change evaluation mode (`always` or `pull`) |
 
-Usage: To initialize superego, ask OpenCode: \"use the superego tool with init\".
+Usage: To initialize superego, ask OpenCode: "use the superego tool with init".
 
-You can also ask it to \"check superego status\".
+### `superego_review` - On-demand evaluation
+
+Use this tool at decision points to get feedback:
+- Before committing to a plan or approach
+- When choosing between alternatives
+- Before non-trivial implementations
+- When the task feels complex or uncertain
+- Before claiming work is done
+
+Requires the current session ID as argument.
 
 ## Test Plan
 


### PR DESCRIPTION
## Summary

- Default to pull mode (matches Claude Code plugin behavior)
- Add `superego_review` tool for on-demand evaluation
- Add `mode` command to switch between `always`/`pull`
- Skip automatic `session.idle` evaluation when in pull mode

This fixes the issue where OpenCode plugin was always running in background even when `mode: pull` was set in config.yaml.

## Test plan

- [ ] Verify default mode is `pull` (no automatic evaluation)
- [ ] Test `superego mode always` command switches to automatic mode
- [ ] Test `superego_review` tool works for manual evaluation
- [ ] Verify `superego status` shows current mode

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced two evaluation modes ("always" and "pull") to control when evaluations run automatically.
  * Added a new "mode" command to view or change the evaluation mode.
  * Added a new "superego_review" tool for on-demand manual evaluation.

* **Documentation**
  * Updated documentation with guidance on evaluation modes and new command usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->